### PR TITLE
Exclude deleted files from linting

### DIFF
--- a/.github/workflows/javalint.yaml
+++ b/.github/workflows/javalint.yaml
@@ -15,9 +15,9 @@ jobs:
       - name: Download google-java-format 1.8
         run: wget -q https://github.com/google/google-java-format/releases/download/google-java-format-1.8/google-java-format-1.8-all-deps.jar
       - name: Format with google-java-format 1.8
-        # Run google-java-format on diffed Java files.
+        # Run google-java-format on diffed Java files excluding deleted files.
         run: |
-          for file in $(git diff --name-only origin/master HEAD -- . ':!node_modules' | grep -E "(.*)\.(java)$"); do
+          for file in $(git diff --diff-filter=d --name-only origin/master HEAD -- . ':!node_modules' | grep -E "(.*)\.(java)$"); do
             echo -e "Running google-java-format on:\n $file\n"
             if ! java -jar ./google-java-format-1.8-all-deps.jar $file | diff $file -; then
               EXIT=1


### PR DESCRIPTION
Currently, the java linter checks diffs against origin/master. Java linter throws error while looking for deleted files in PR. This PR will change the linter behavior to exclude deleted files